### PR TITLE
Update vhdl.configuration.json to enable --#region --#endregion for VHDL

### DIFF
--- a/packages/teroshdl/configs/vhdl.configuration.json
+++ b/packages/teroshdl/configs/vhdl.configuration.json
@@ -34,5 +34,12 @@
         "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*(elsif|else|end|begin)\\b",
         // `^((?!.*?/\*).*\*/)??` ignore any text in a comment at the start of the line
         // `\s*(elsif|else|end|begin)\b)` decrease indent on a line starting with these keywords
+    },
+
+    "folding": { // enable folding/minimap labels for --#region <Label> ... --#endregion <Label>
+        "markers": {
+            "start": "^\\s*\\-\\-\\s*#?region\\b",
+            "end": "^\\s*\\-\\-\\s*#?endregion\\b"
+        }
     }
 }


### PR DESCRIPTION
enable folding/minimap labels for regions in VHDL

use 
--#region <Label> 
    [...]
--#endregion <Label>
in .vhdl sources to group code regions and show <Label> markers on the minimap of VSCode